### PR TITLE
fix: keep chat autoscroll inside the message container

### DIFF
--- a/app/src/components/MainPanel.tsx
+++ b/app/src/components/MainPanel.tsx
@@ -24,7 +24,11 @@ export default function MainPanel() {
 
   const scrollToBottom = (behavior: ScrollBehavior = 'smooth') => {
     requestAnimationFrame(() => {
-      messagesEndRef.current?.scrollIntoView({ behavior })
+      if (!containerRef.current) return
+      containerRef.current.scrollTo({
+        top: containerRef.current.scrollHeight,
+        behavior,
+      })
     })
     setShouldAutoScroll(true)
     setShowScrollButton(false)


### PR DESCRIPTION
Fixes chat autoscroll so long conversations no longer shift the whole chat area upward.
Replaced `scrollIntoView()` with an explicit `scrollTo()` on the messages container to keep scrolling scoped correctly.

See attached screenshot for the original issue 
<img width="1732" height="867" alt="clip-20260412-104012" src="https://github.com/user-attachments/assets/4b70205d-4516-43de-a484-2d73a1428326" />
