### PR TITLE
feat: add zen mode and collapsed sidebar

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,9 +15,10 @@ import TitleBar from './components/TitleBar.tsx'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 
 function App() {
-  const { view } = useUIStore()
+  const { view, zenMode } = useUIStore()
   const { monitoringEnabled, isMonitoring, startMonitoring } = useMonitoringStore()
   const { theme, loadSettingsFromBackend } = useSettingsStore()
+  const isZenMode = view === 'chat' && zenMode
 
   // Load settings on mount
   useEffect(() => {
@@ -54,13 +55,11 @@ function App() {
   return (
     <div className="flex h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 overflow-hidden pt-8">
       <TitleBar />
-      {/* Left Sidebar */}
-      <Sidebar />
+      {!isZenMode && <Sidebar />}
 
-      {/* Main Content Area */}
       <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-        <TopBar />
-        {view === 'chat' && <MainPanel />}
+        {!isZenMode && <TopBar />}
+        {view === 'chat' && <MainPanel isZenMode={isZenMode} />}
         {view === 'models' && <div className="flex-1 overflow-auto bg-white dark:bg-gray-900"><ModelsRoute /></div>}
         {view === 'settings' && <div className="flex-1 overflow-auto bg-white dark:bg-gray-900"><SettingsRoute /></div>}
         {view === 'monitoring' && <div className="flex-1 overflow-auto bg-gray-50 dark:bg-gray-950"><MonitoringDashboard /></div>}

--- a/app/src/components/MainPanel.tsx
+++ b/app/src/components/MainPanel.tsx
@@ -1,10 +1,11 @@
-import { ArrowUp, Square, ArrowDown, Paperclip, X, FileText, Search, Brain } from 'lucide-react'
+import { ArrowUp, Square, ArrowDown, Paperclip, X, FileText, Search, Brain, Minimize2 } from 'lucide-react'
 import { useState, useEffect, useRef } from 'react'
 import { useChatStore } from '../store/chatStore'
 import Message from './Message'
 import { extractPdfText } from '../lib/pdf'
+import { useUIStore } from '../store/uiStore'
 
-export default function MainPanel() {
+export default function MainPanel({ isZenMode = false }: { isZenMode?: boolean }) {
   const [message, setMessage] = useState('')
   const [showScrollButton, setShowScrollButton] = useState(false)
   const [shouldAutoScroll, setShouldAutoScroll] = useState(true)
@@ -18,9 +19,11 @@ export default function MainPanel() {
     messages,
     sendMessage,
     currentModel,
+    isLoadingChat,
     isStreaming,
     stopStreaming
   } = useChatStore()
+  const { setZenMode } = useUIStore()
 
   const scrollToBottom = (behavior: ScrollBehavior = 'smooth') => {
     requestAnimationFrame(() => {
@@ -153,16 +156,40 @@ export default function MainPanel() {
   const hasMessages = messages.length > 0
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 overflow-hidden bg-white dark:bg-gray-900 relative">
+    <div className={`flex-1 flex flex-col min-h-0 overflow-hidden relative ${isZenMode ? 'bg-gray-50 dark:bg-gray-950' : 'bg-white dark:bg-gray-900'}`}>
+      {isZenMode && (
+        <div className="absolute top-4 right-4 z-20">
+          <button
+            onClick={() => setZenMode(false)}
+            className="ui-surface ui-muted hover:text-gray-900 dark:hover:text-gray-100 rounded-xl p-2 shadow-sm transition-all"
+            title="Exit zen mode"
+          >
+            <Minimize2 size={16} />
+          </button>
+        </div>
+      )}
+
       {/* Chat Messages Area */}
       <div
         ref={containerRef}
         onScroll={handleScroll}
         className="flex-1 min-h-0 overflow-y-auto scroll-smooth"
       >
-        {!hasMessages ? (
+        {isLoadingChat ? (
+          <div className={`flex flex-col items-center justify-center h-full p-8 ${isZenMode ? 'max-w-3xl' : 'max-w-4xl'} mx-auto`}>
+            <div className="text-center w-full max-w-md">
+              <div className="w-10 h-10 mx-auto mb-5 rounded-full border-2 border-gray-200 dark:border-gray-700 border-t-gray-900 dark:border-t-gray-100 animate-spin" />
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                Loading chat
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Fetching messages and restoring the conversation state.
+              </p>
+            </div>
+          </div>
+        ) : !hasMessages ? (
           /* Welcome Message */
-          <div className="flex flex-col items-center justify-center h-full p-8 max-w-4xl mx-auto">
+          <div className={`flex flex-col items-center justify-center h-full p-8 ${isZenMode ? 'max-w-3xl' : 'max-w-4xl'} mx-auto`}>
             <div className="text-center w-full">
               {/* Ollie Logo */}
               <div className="w-20 h-20 flex items-center justify-center mx-auto mb-8 shadow-none">
@@ -181,7 +208,8 @@ export default function MainPanel() {
               </p>
 
               {/* Quick Start Examples - Minimalist Design */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+              {!isZenMode && (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
                 <button
                   onClick={() => setMessage('Explain how this code works')}
                   className="ui-surface p-5 hover:border-gray-300 dark:hover:border-gray-600 rounded-xl text-left transition-all duration-200 group hover:shadow-md"
@@ -245,13 +273,14 @@ export default function MainPanel() {
                     </div>
                   </div>
                 </button>
-              </div>
+                </div>
+              )}
             </div>
           </div>
         ) : (
           /* Chat Messages */
-          <div className="w-full px-6 sm:px-8 lg:px-12 py-6 overflow-x-hidden">
-            <div className="max-w-4xl mx-auto">
+          <div className={`w-full py-6 overflow-x-hidden ${isZenMode ? 'px-4 sm:px-6 lg:px-8' : 'px-6 sm:px-8 lg:px-12'}`}>
+            <div className={`${isZenMode ? 'max-w-3xl' : 'max-w-4xl'} mx-auto`}>
               {messages.map((msg) => (
                 <Message key={msg.id} message={msg} />
               ))}
@@ -273,7 +302,7 @@ export default function MainPanel() {
       )}
 
       {/* Input Area - constrained to max 40% of height */}
-      <div className="border-t border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-950/80 backdrop-blur-sm flex-shrink-0 max-h-[40vh] overflow-y-auto">
+      <div className={`border-t flex-shrink-0 max-h-[40vh] overflow-y-auto ${isZenMode ? 'border-gray-200/80 dark:border-gray-800 bg-white/90 dark:bg-gray-900/90 backdrop-blur-md' : 'border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-950/80 backdrop-blur-sm'}`}>
         <div className="w-full max-w-3xl mx-auto p-4 sm:p-6">
           <div className="relative">
             {/* Attachment Preview Area */}
@@ -352,14 +381,16 @@ export default function MainPanel() {
             </div>
           </div>
 
-          <div className="flex justify-center mt-3 mb-2">
-            <p className="text-[11px] text-gray-400 dark:text-gray-500 font-medium tracking-wide">
-              {currentModel
-                ? 'Ollie can make mistakes. Consider checking important information.'
-                : 'Select a model to start chatting'
-              }
-            </p>
-          </div>
+          {!isZenMode && (
+            <div className="flex justify-center mt-3 mb-2">
+              <p className="text-[11px] text-gray-400 dark:text-gray-500 font-medium tracking-wide">
+                {currentModel
+                  ? 'Ollie can make mistakes. Consider checking important information.'
+                  : 'Select a model to start chatting'
+                }
+              </p>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
-import { Settings, Database, Plus, Search, Trash2, Activity, Bot } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { Settings, Database, Plus, Search, Trash2, Activity, Bot, MessageSquare, PanelLeftOpen, PanelLeftClose } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useUIStore } from '../store/uiStore'
 import { invoke } from '@tauri-apps/api/core'
 import { useChatStore } from '../store/chatStore'
@@ -17,10 +17,13 @@ type ChatMeta = {
 
 export default function Sidebar() {
   const [searchQuery, setSearchQuery] = useState('')
+  const [collapsedChatQuery, setCollapsedChatQuery] = useState('')
+  const [collapsedChatPickerOpen, setCollapsedChatPickerOpen] = useState(false)
   const [chats, setChats] = useState<ChatMeta[]>([])
   const [previews, setPreviews] = useState<Record<string, string>>({})
+  const collapsedPickerRef = useRef<HTMLDivElement>(null)
   const { loadChat, createNewChat, currentChatId } = useChatStore()
-  const { view: currentView, setView } = useUIStore()
+  const { view: currentView, setView, sidebarCollapsed, setSidebarCollapsed } = useUIStore()
 
   const [deleteId, setDeleteId] = useState<string | null>(null)
   const [alertMsg, setAlertMsg] = useState<string | null>(null)
@@ -29,7 +32,6 @@ export default function Sidebar() {
     try {
       const rows = await invoke<any>('db_list_chats_with_flags', { limit: 200 })
       setChats(rows as ChatMeta[])
-      // Load a short preview for each chat (best-effort)
       const list = rows as ChatMeta[]
       const entries: Record<string, string> = {}
       for (const c of list) {
@@ -40,7 +42,7 @@ export default function Sidebar() {
             const m = msgs[0] as any
             const raw = String(m.content || '')
             const oneLine = raw.replace(/\s+/g, ' ').trim()
-            const trimmed = oneLine.length > 80 ? oneLine.slice(0, 80) + '…' : oneLine
+            const trimmed = oneLine.length > 80 ? `${oneLine.slice(0, 80)}…` : oneLine
             entries[c.id] = trimmed
           }
         } catch { }
@@ -59,170 +61,333 @@ export default function Sidebar() {
     return () => window.removeEventListener('chats-refresh', onRefresh as EventListener)
   }, [])
 
-  // simple filter by model or id
   const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase()
     if (!q) return chats
     return chats.filter(c => (c.model || '').toLowerCase().includes(q) || c.id.toLowerCase().includes(q))
   }, [searchQuery, chats])
 
+  const collapsedFiltered = useMemo(() => {
+    const q = collapsedChatQuery.trim().toLowerCase()
+    if (!q) return chats
+    return chats.filter(c =>
+      (c.title || '').toLowerCase().includes(q) ||
+      (c.model || '').toLowerCase().includes(q) ||
+      c.id.toLowerCase().includes(q)
+    )
+  }, [collapsedChatQuery, chats])
+
+  useEffect(() => {
+    if (!collapsedChatPickerOpen) return
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!collapsedPickerRef.current?.contains(event.target as Node)) {
+        setCollapsedChatPickerOpen(false)
+      }
+    }
+
+    window.addEventListener('mousedown', handlePointerDown)
+    return () => window.removeEventListener('mousedown', handlePointerDown)
+  }, [collapsedChatPickerOpen])
+
+  const handleSelectChat = async (chat: ChatMeta) => {
+    if (chat.model) {
+      useChatStore.getState().setCurrentModel(chat.model)
+    }
+    await loadChat(chat.id, chat.system_prompt, chat.title)
+    setView('chat')
+    setCollapsedChatPickerOpen(false)
+  }
+
+  const handleCreateChat = async () => {
+    const { messages } = useChatStore.getState()
+    if (currentChatId && messages.length === 0) {
+      setAlertMsg('Finish or start a conversation in the current chat before creating a new one.')
+      return
+    }
+
+    if (!currentChatId && chats.length > 0) {
+      try {
+        const latest = chats[0]
+        const rows = await invoke<any>('db_list_messages', { chatId: latest.id, limit: 1 })
+        if (Array.isArray(rows) && rows.length === 0) {
+          setAlertMsg('Your most recent chat is empty. Send a message first before creating a new chat.')
+          return
+        }
+      } catch { }
+    }
+
+    const id = await createNewChat()
+    if (id) {
+      await refreshChats()
+      setView('chat')
+    }
+  }
+
   return (
-    <div className="w-72 bg-gray-50/50 dark:bg-gray-900 border-r border-gray-200/80 dark:border-gray-800 flex flex-col overflow-hidden">
-      {/* Header with Ollama Logo */}
-      <div className="p-4 border-b border-gray-200/60 dark:border-gray-800">
-        <div className="flex items-center gap-2.5 mb-4">
-          <div className="w-8 h-8 flex items-center justify-center flex-shrink-0">
-            <img src="/ollie-logo.png" alt="Ollie" className="w-full h-full object-contain" />
-          </div>
-          <div>
-            <h1 className="ui-heading text-base font-semibold">Ollie</h1>
-            <p className="ui-muted text-[10px]">AI Chat Interface</p>
-          </div>
-        </div>
-
-        {/* New Chat Button */}
-        <button
-          onClick={async () => {
-            const { messages } = useChatStore.getState()
-            // Prevent creating a new chat if the current chat is empty (no messages)
-            if (currentChatId && messages.length === 0) {
-              setAlertMsg('Finish or start a conversation in the current chat before creating a new one.')
-              return
-            }
-            // If no currentChatId, ensure the most recent chat is not empty either
-            if (!currentChatId && chats.length > 0) {
-              try {
-                const latest = chats[0]
-                const rows = await invoke<any>('db_list_messages', { chatId: latest.id, limit: 1 })
-                if (Array.isArray(rows) && rows.length === 0) {
-                  setAlertMsg('Your most recent chat is empty. Send a message first before creating a new chat.')
-                  return
-                }
-              } catch { }
-            }
-            const id = await createNewChat()
-            if (id) {
-              await refreshChats()
+    <>
+      {sidebarCollapsed ? (
+        <div className="relative z-20 w-20 bg-gray-50/50 dark:bg-gray-900 border-r border-gray-200/80 dark:border-gray-800 flex flex-col items-center py-4 gap-4 overflow-visible">
+          <button
+            onClick={() => {
+              setSidebarCollapsed(false)
               setView('chat')
-            }
-          }}
-          className="ui-button-primary-muted w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg transition-all duration-150 text-sm font-medium"
-        >
-          <Plus size={16} strokeWidth={2} />
-          <span>New chat</span>
-        </button>
-      </div>
+            }}
+            className="w-11 h-11 flex items-center justify-center rounded-2xl ui-surface hover:border-gray-300 dark:hover:border-gray-600 transition-all"
+            title="Open sidebar"
+          >
+            <img src="/ollie-logo.png" alt="Ollie" className="w-7 h-7 object-contain" />
+          </button>
 
-      {/* Search */}
-      <div className="px-4 py-3 border-b border-gray-200/60 dark:border-gray-800">
-        <div className="relative">
-          <Search size={14} className="absolute left-2.5 top-1/2 transform -translate-y-1/2 text-gray-400" />
-          <input
-            type="text"
-            placeholder="Search..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="ui-input ui-input-focus w-full pl-8 pr-3 py-2 rounded-md text-xs transition-all duration-150"
-          />
-        </div>
-      </div>
+          <button
+            onClick={() => setSidebarCollapsed(false)}
+            className="ui-icon-button"
+            title="Expand sidebar"
+          >
+            <PanelLeftOpen size={18} />
+          </button>
 
-      {/* Chat List */}
-      <div className="flex-1 overflow-y-auto px-3 py-2">
-        <div className="space-y-0.5">
-          {filtered.length === 0 ? (
-            <div className="py-12 text-center text-gray-500">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Bot size={20} className="text-gray-400" />
-              </div>
-              <div className="text-sm font-medium">No conversations yet</div>
-              <div className="text-xs text-gray-400 mt-1">Start a new chat to see it here</div>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {filtered.map((c) => (
-                <div key={c.id} className="relative flex items-center gap-3 group">
-                  <button
-                    onClick={async () => {
-                      // If chat has a preferred model, set it
-                      if (c.model) {
-                        useChatStore.getState().setCurrentModel(c.model)
-                      }
-                      await loadChat(c.id, c.system_prompt)
-                      setView('chat')
-                    }}
-                    className={`flex-1 min-w-0 text-left px-4 py-3 rounded-xl border transition-all duration-200 ${currentChatId === c.id
-                      ? 'bg-gray-50 border-gray-200 shadow-sm dark:bg-gray-800 dark:border-gray-700'
-                      : 'bg-white hover:bg-gray-50 border-transparent hover:border-gray-100 hover:shadow-sm dark:bg-gray-900 dark:hover:bg-gray-800 dark:hover:border-gray-700'
-                      }`}
-                  >
-                    <div className="flex items-center gap-3 mb-1">
-                      <div className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0"></div>
-                      <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
-                        {c.title || 'Untitled chat'}
+          <button
+            onClick={handleCreateChat}
+            className="ui-icon-button"
+            title="New chat"
+          >
+            <Plus size={18} />
+          </button>
+
+          <div className="w-10 h-px bg-gray-200 dark:bg-gray-800" />
+
+          <div className="flex flex-col items-center gap-2">
+            <div ref={collapsedPickerRef} className="relative">
+              <SidebarIconButton
+                icon={<MessageSquare size={18} />}
+                label="Chat"
+                isActive={currentView === 'chat' || collapsedChatPickerOpen}
+                onClick={() => {
+                  setView('chat')
+                  setCollapsedChatPickerOpen((open) => !open)
+                }}
+              />
+
+              {collapsedChatPickerOpen && (
+                <div className="absolute left-14 top-0 w-80 ui-dropdown rounded-2xl shadow-2xl overflow-hidden z-40">
+                  <div className="p-3 border-b border-gray-200 dark:border-gray-700">
+                    <div className="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                      Chats
+                    </div>
+                    <div className="relative">
+                      <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" />
+                      <input
+                        type="text"
+                        placeholder="Search chats..."
+                        value={collapsedChatQuery}
+                        onChange={(e) => setCollapsedChatQuery(e.target.value)}
+                        className="ui-input ui-input-focus w-full pl-8 pr-3 py-2 rounded-md text-xs transition-all duration-150"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="max-h-[420px] overflow-y-auto p-2">
+                    {collapsedFiltered.length === 0 ? (
+                      <div className="px-3 py-8 text-center">
+                        <div className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                          No chats found
+                        </div>
+                        <div className="text-xs text-gray-400 mt-1">
+                          Try a different search
+                        </div>
                       </div>
-                    </div>
-
-                    <div className="flex items-center gap-2 ml-5 mb-1.5">
-                      <span className="ui-chip-sm">
-                        {c.model || 'Unknown model'}
-                      </span>
-                      <span className="text-[10px] text-gray-400">
-                        {new Date(c.updated_at).toLocaleDateString()}
-                      </span>
-                    </div>
-
-                    {previews[c.id] && (
-                      <div className="text-xs text-gray-500 truncate ml-5">
-                        {previews[c.id]}
+                    ) : (
+                      <div className="space-y-1">
+                        {collapsedFiltered.map((chat) => (
+                          <button
+                            key={chat.id}
+                            onClick={() => handleSelectChat(chat)}
+                            className={`w-full text-left rounded-xl px-3 py-3 border transition-all duration-150 ${currentChatId === chat.id
+                              ? 'bg-gray-50 border-gray-200 shadow-sm dark:bg-gray-700 dark:border-gray-600'
+                              : 'border-transparent hover:bg-gray-50 dark:hover:bg-gray-700/80 hover:border-gray-200 dark:hover:border-gray-600'
+                              }`}
+                          >
+                            <div className="flex items-center gap-2 mb-1">
+                              <div className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
+                              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                                {chat.title || 'Untitled chat'}
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-2 ml-4 mb-1">
+                              <span className="ui-chip-sm">{chat.model || 'Unknown model'}</span>
+                              <span className="text-[10px] text-gray-400">
+                                {new Date(chat.updated_at).toLocaleDateString()}
+                              </span>
+                            </div>
+                            {previews[chat.id] && (
+                              <div className="ml-4 text-xs text-gray-500 truncate">
+                                {previews[chat.id]}
+                              </div>
+                            )}
+                          </button>
+                        ))}
                       </div>
                     )}
-                  </button>
-                  <button
-                    title={c.has_messages ? 'Delete chat' : 'Cannot delete an empty chat'}
-                    className={`absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-md transition-all duration-200 ${c.has_messages
-                      ? 'text-gray-300 hover:text-red-600 hover:bg-red-50'
-                      : 'hidden'
-                      }`}
-                    onClick={async (e) => {
-                      e.stopPropagation()
-                      if (!c.has_messages) return
-                      setDeleteId(c.id)
-                    }}
-                  >
-                    <Trash2 size={14} />
-                  </button>
+                  </div>
                 </div>
-              ))}
+              )}
             </div>
-          )}
+            <SidebarIconButton
+              icon={<Activity size={18} />}
+              label="Monitoring"
+              isActive={currentView === 'monitoring'}
+              onClick={() => setView('monitoring')}
+            />
+            <SidebarIconButton
+              icon={<Database size={18} />}
+              label="Manage models"
+              isActive={currentView === 'models'}
+              onClick={() => setView('models')}
+            />
+            <SidebarIconButton
+              icon={<Settings size={18} />}
+              label="Settings"
+              isActive={currentView === 'settings'}
+              onClick={() => setView('settings')}
+            />
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="w-72 bg-gray-50/50 dark:bg-gray-900 border-r border-gray-200/80 dark:border-gray-800 flex flex-col overflow-hidden">
+          <div className="p-4 border-b border-gray-200/60 dark:border-gray-800">
+            <div className="flex items-start justify-between gap-3 mb-4">
+              <div className="flex items-center gap-2.5 min-w-0">
+                <div className="w-8 h-8 flex items-center justify-center flex-shrink-0">
+                  <img src="/ollie-logo.png" alt="Ollie" className="w-full h-full object-contain" />
+                </div>
+                <div className="min-w-0">
+                  <h1 className="ui-heading text-base font-semibold">Ollie</h1>
+                  <p className="ui-muted text-[10px]">AI Chat Interface</p>
+                </div>
+              </div>
+              <button
+                onClick={() => setSidebarCollapsed(true)}
+                className="ui-icon-button p-2"
+                title="Collapse sidebar"
+              >
+                <PanelLeftClose size={16} />
+              </button>
+            </div>
 
-      {/* Bottom Navigation */}
-      <div className="p-4 border-t border-gray-100">
-        <div className="space-y-1">
-          <MenuButton
-            icon={<Activity size={18} />}
-            label="Monitoring"
-            isActive={currentView === 'monitoring'}
-            onClick={() => setView('monitoring')}
-          />
-          <MenuButton
-            icon={<Database size={18} />}
-            label="Manage models"
-            isActive={currentView === 'models'}
-            onClick={() => setView('models')}
-          />
-          <MenuButton
-            icon={<Settings size={18} />}
-            label="Settings"
-            isActive={currentView === 'settings'}
-            onClick={() => setView('settings')}
-          />
+            <button
+              onClick={handleCreateChat}
+              className="ui-button-primary-muted w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg transition-all duration-150 text-sm font-medium"
+            >
+              <Plus size={16} strokeWidth={2} />
+              <span>New chat</span>
+            </button>
+          </div>
+
+          <div className="px-4 py-3 border-b border-gray-200/60 dark:border-gray-800">
+            <div className="relative">
+              <Search size={14} className="absolute left-2.5 top-1/2 transform -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                placeholder="Search..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="ui-input ui-input-focus w-full pl-8 pr-3 py-2 rounded-md text-xs transition-all duration-150"
+              />
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-3 py-2">
+            <div className="space-y-0.5">
+              {filtered.length === 0 ? (
+                <div className="py-12 text-center text-gray-500">
+                  <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4 dark:bg-gray-800">
+                    <Bot size={20} className="text-gray-400" />
+                  </div>
+                  <div className="text-sm font-medium">No conversations yet</div>
+                  <div className="text-xs text-gray-400 mt-1">Start a new chat to see it here</div>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {filtered.map((c) => (
+                    <div key={c.id} className="relative flex items-center gap-3 group">
+                      <button
+                        onClick={async () => {
+                          await handleSelectChat(c)
+                        }}
+                        className={`flex-1 min-w-0 text-left px-4 py-3 rounded-xl border transition-all duration-200 ${currentChatId === c.id
+                          ? 'bg-gray-50 border-gray-200 shadow-sm dark:bg-gray-800 dark:border-gray-700'
+                          : 'bg-white hover:bg-gray-50 border-transparent hover:border-gray-100 hover:shadow-sm dark:bg-gray-900 dark:hover:bg-gray-800 dark:hover:border-gray-700'
+                          }`}
+                      >
+                        <div className="flex items-center gap-3 mb-1">
+                          <div className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0"></div>
+                          <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                            {c.title || 'Untitled chat'}
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-2 ml-5 mb-1.5">
+                          <span className="ui-chip-sm">
+                            {c.model || 'Unknown model'}
+                          </span>
+                          <span className="text-[10px] text-gray-400">
+                            {new Date(c.updated_at).toLocaleDateString()}
+                          </span>
+                        </div>
+
+                        {previews[c.id] && (
+                          <div className="text-xs text-gray-500 truncate ml-5">
+                            {previews[c.id]}
+                          </div>
+                        )}
+                      </button>
+                      <button
+                        title={c.has_messages ? 'Delete chat' : 'Cannot delete an empty chat'}
+                        className={`absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-md transition-all duration-200 ${c.has_messages
+                          ? 'text-gray-300 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40 dark:hover:text-red-300'
+                          : 'hidden'
+                          }`}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          if (!c.has_messages) return
+                          setDeleteId(c.id)
+                        }}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="p-4 border-t border-gray-100 dark:border-gray-800">
+            <div className="space-y-1">
+              <MenuButton
+                icon={<Activity size={18} />}
+                label="Monitoring"
+                isActive={currentView === 'monitoring'}
+                onClick={() => setView('monitoring')}
+              />
+              <MenuButton
+                icon={<Database size={18} />}
+                label="Manage models"
+                isActive={currentView === 'models'}
+                onClick={() => setView('models')}
+              />
+              <MenuButton
+                icon={<Settings size={18} />}
+                label="Settings"
+                isActive={currentView === 'settings'}
+                onClick={() => setView('settings')}
+              />
+            </div>
+          </div>
         </div>
-      </div>
-      {/* Alert Dialog */}
+      )}
+
       <Dialog
         isOpen={!!alertMsg}
         title="Cannot Create Chat"
@@ -233,7 +398,6 @@ export default function Sidebar() {
         onCancel={() => setAlertMsg(null)}
       />
 
-      {/* Delete Confirmation Dialog */}
       <Dialog
         isOpen={!!deleteId}
         title="Delete Chat?"
@@ -260,7 +424,7 @@ export default function Sidebar() {
         }}
         onCancel={() => setDeleteId(null)}
       />
-    </div>
+    </>
   )
 }
 
@@ -277,6 +441,21 @@ function MenuButton({ icon, label, isActive, onClick }: { icon: React.ReactNode,
         {icon}
       </div>
       <span>{label}</span>
+    </button>
+  )
+}
+
+function SidebarIconButton({ icon, label, isActive, onClick }: { icon: React.ReactNode, label: string, isActive: boolean, onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      title={label}
+      className={`w-11 h-11 rounded-xl flex items-center justify-center transition-all duration-200 ${isActive
+        ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 shadow-md'
+        : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100'
+        }`}
+    >
+      {icon}
     </button>
   )
 }

--- a/app/src/components/TitleBar.tsx
+++ b/app/src/components/TitleBar.tsx
@@ -1,10 +1,18 @@
 import { Minus, Square, X, Maximize2 } from 'lucide-react'
 import { Window } from '@tauri-apps/api/window'
 import { useState, useEffect } from 'react'
+import { useChatStore } from '../store/chatStore'
+import { useUIStore } from '../store/uiStore'
 
 export default function TitleBar() {
     const [isMaximized, setIsMaximized] = useState(false)
     const appWindow = Window.getCurrent()
+    const { currentChatTitle, currentModel } = useChatStore()
+    const { view, zenMode } = useUIStore()
+    const isZenMode = view === 'chat' && zenMode
+    const windowLabel = isZenMode
+        ? [currentChatTitle || 'Untitled chat', currentModel || null].filter(Boolean).join(' · ')
+        : 'Ollie'
 
     useEffect(() => {
         const checkMaximized = async () => {
@@ -38,7 +46,13 @@ export default function TitleBar() {
         <div data-tauri-drag-region className="h-8 bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border-b border-gray-200/80 dark:border-gray-800 flex items-center justify-between select-none fixed top-0 left-0 right-0 z-50">
             {/* Title / Drag Area */}
             <div className="flex-1 h-full flex items-center px-4" data-tauri-drag-region>
-                <span className="text-[11px] font-medium text-gray-400 dark:text-gray-500 pointer-events-none tracking-wide uppercase">Ollie</span>
+                <span className={`pointer-events-none truncate ${isZenMode
+                    ? 'text-xs font-medium text-gray-500 dark:text-gray-400 normal-case tracking-normal max-w-[70vw]'
+                    : 'text-[11px] font-medium text-gray-400 dark:text-gray-500 tracking-wide uppercase'
+                    }`}
+                >
+                    {windowLabel}
+                </span>
             </div>
 
             {/* Window Controls */}

--- a/app/src/components/TopBar.tsx
+++ b/app/src/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import { Square, Settings2, AlertCircle, Cloud, Zap } from 'lucide-react'
+import { Square, Settings2, AlertCircle, Cloud, Zap, Maximize2 } from 'lucide-react'
 import { useState } from 'react'
 import ModelSelector from './ModelSelector'
 import ParametersPanel from './ParametersPanel'
@@ -6,10 +6,12 @@ import ThemeToggle from './ThemeToggle'
 import { useOllamaHealth } from '../lib/hooks'
 import { useSettingsStore } from '../store/settingsStore'
 import { useChatStore } from '../store/chatStore'
+import { useUIStore } from '../store/uiStore'
 
 export default function TopBar() {
   const { serverUrl, serverPort, appMode, providers, activeProviderId } = useSettingsStore()
   const { isStreaming, stopStreaming } = useChatStore()
+  const { view, zenMode, toggleZenMode } = useUIStore()
   const [parametersOpen, setParametersOpen] = useState(false)
 
   // Get active provider info
@@ -95,6 +97,20 @@ export default function TopBar() {
           >
             <Square size={12} />
             <span>Stop</span>
+          </button>
+        )}
+
+        {view === 'chat' && (
+          <button
+            onClick={toggleZenMode}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md transition-all duration-150 ${zenMode
+              ? 'ui-button-secondary-active'
+              : 'ui-button-secondary'
+              }`}
+            title={zenMode ? 'Exit zen mode' : 'Enter zen mode'}
+          >
+            <Maximize2 size={14} />
+            <span className="text-xs font-medium">Zen</span>
           </button>
         )}
 

--- a/app/src/store/chatStore.ts
+++ b/app/src/store/chatStore.ts
@@ -31,7 +31,9 @@ export interface ChatOptions {
 interface ChatState {
   messages: ChatMessage[]
   currentChatId: string | null
+  currentChatTitle: string | null
   currentModel: string
+  isLoadingChat: boolean
   isStreaming: boolean
   streamingMessageId: string | null
   currentStreamId: string | null  // Track current stream ID
@@ -40,9 +42,10 @@ interface ChatState {
   // Actions
   setCurrentModel: (model: string) => void
   setCurrentChatId: (chatId: string | null) => void
+  setCurrentChatTitle: (title: string | null) => void
   setCurrentSystemPrompt: (prompt: string | null) => void
   createNewChat: (opts?: { model?: string; systemPrompt?: string; paramsJson?: string }) => Promise<string | null>
-  loadChat: (chatId: string, systemPrompt?: string | null) => Promise<boolean>
+  loadChat: (chatId: string, systemPrompt?: string | null, title?: string | null) => Promise<boolean>
   addMessage: (message: Omit<ChatMessage, 'id' | 'timestamp'>) => string
   updateMessage: (id: string, content: string) => void
   updateStreamingMessage: (id: string, content: string) => void
@@ -59,7 +62,9 @@ interface ChatState {
 export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
   currentChatId: null,
+  currentChatTitle: null,
   currentModel: '',
+  isLoadingChat: false,
   isStreaming: false,
   streamingMessageId: null,
   currentStreamId: null,
@@ -67,6 +72,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   setCurrentModel: (model) => set({ currentModel: model }),
   setCurrentChatId: (chatId) => set({ currentChatId: chatId }),
+  setCurrentChatTitle: (currentChatTitle) => set({ currentChatTitle }),
   setCurrentSystemPrompt: (prompt) => set({ currentSystemPrompt: prompt }),
 
   createNewChat: async (opts) => {
@@ -78,7 +84,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
       })
       const chatId = res?.id as string
       // Store the system prompt in state so we use it immediately
-      set({ currentChatId: chatId, messages: [], currentSystemPrompt: res?.system_prompt || null })
+      set({
+        currentChatId: chatId,
+        currentChatTitle: res?.title || null,
+        messages: [],
+        currentSystemPrompt: res?.system_prompt || null,
+        isLoadingChat: false,
+      })
       return chatId
     } catch (e) {
       console.error('db_create_chat failed', e)
@@ -86,13 +98,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }
   },
 
-  loadChat: async (chatId: string, systemPrompt?: string | null) => {
+  loadChat: async (chatId: string, systemPrompt?: string | null, title?: string | null) => {
     try {
       const state = get()
       if (state.isStreaming) {
         await state.stopStreaming()
       }
-      set({ currentChatId: chatId, messages: [], currentSystemPrompt: systemPrompt || null })
+      set({
+        currentChatId: chatId,
+        currentChatTitle: title || null,
+        messages: [],
+        currentSystemPrompt: systemPrompt || null,
+        isLoadingChat: true,
+      })
       const rows = await invoke<any>('db_list_messages', { chatId, limit: 1000 })
       const msgs: ChatMessage[] = (rows as any[]).map((r) => {
         let images: string[] | undefined
@@ -113,10 +131,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
           timestamp: Number(r.created_at) || Date.now(),
         }
       })
-      set({ messages: msgs })
+      set({ messages: msgs, isLoadingChat: false })
       return true
     } catch (e) {
       console.error('db_list_messages failed', e)
+      set({ isLoadingChat: false })
       return false
     }
   },
@@ -784,7 +803,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   clearMessages: () => {
-    set({ messages: [], isStreaming: false, streamingMessageId: null })
+    set({ messages: [], currentChatTitle: null, isLoadingChat: false, isStreaming: false, streamingMessageId: null })
   },
 
   generateAutoTitle: async (chatId, userContent) => {
@@ -902,6 +921,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     if (cleanTitle) {
       await invoke('db_set_chat_title', { chatId, title: cleanTitle })
+      if (get().currentChatId === chatId) {
+        set({ currentChatTitle: cleanTitle })
+      }
       window.dispatchEvent(new CustomEvent('chats-refresh'))
     }
   }

--- a/app/src/store/uiStore.ts
+++ b/app/src/store/uiStore.ts
@@ -1,13 +1,46 @@
 import { create } from 'zustand'
 
 type View = 'chat' | 'models' | 'settings' | 'monitoring'
+const SIDEBAR_COLLAPSED_KEY = 'ollie.sidebarCollapsed'
+
+const getInitialSidebarCollapsed = () => {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true'
+}
+
+const persistSidebarCollapsed = (collapsed: boolean) => {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(collapsed))
+}
 
 interface UIState {
   view: View
+  sidebarCollapsed: boolean
+  zenMode: boolean
   setView: (v: View) => void
+  setSidebarCollapsed: (collapsed: boolean) => void
+  toggleSidebar: () => void
+  setZenMode: (enabled: boolean) => void
+  toggleZenMode: () => void
 }
 
 export const useUIStore = create<UIState>((set) => ({
   view: 'chat',
-  setView: (view) => set({ view })
+  sidebarCollapsed: getInitialSidebarCollapsed(),
+  zenMode: false,
+  setView: (view) => set((state) => ({
+    view,
+    zenMode: view === 'chat' ? state.zenMode : false,
+  })),
+  setSidebarCollapsed: (sidebarCollapsed) => {
+    persistSidebarCollapsed(sidebarCollapsed)
+    set({ sidebarCollapsed })
+  },
+  toggleSidebar: () => set((state) => {
+    const sidebarCollapsed = !state.sidebarCollapsed
+    persistSidebarCollapsed(sidebarCollapsed)
+    return { sidebarCollapsed }
+  }),
+  setZenMode: (zenMode) => set({ zenMode }),
+  toggleZenMode: () => set((state) => ({ zenMode: !state.zenMode })),
 }))


### PR DESCRIPTION
- add a collapsible sidebar with persisted collapsed state and in-sidebar expand/collapse controls
- add a dedicated zen mode that hides extra chrome and shows chat context in the title bar
- add chat selection in collapsed mode through a compact picker with search and previews
- improve chat switching with an explicit loading state instead of showing the empty chat welcome screen